### PR TITLE
埋め込みコードでグラフを引用し、SNSに投稿すると、画像が東京都のもので表示されるのを修正

### DIFF
--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -3,7 +3,7 @@ name: OGP Builder
 on:
   push:
     branches:
-      - staging
+      - master
 
 jobs:
   build:

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -101,7 +101,7 @@ export default {
     return data
   },
   head() {
-    const url = 'https://stopcovid19.metro.tokyo.lg.jp'
+    const url = 'https://covid19-tochigi.netlify.app'
     const timestamp = new Date().getTime()
     const ogpImage =
       this.$i18n.locale === 'ja'


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #50 

## ⛏ 変更内容 / Details of Changes
- わざわざ東京都版のOGP画像を取得していたので、栃木県版のを取得しに行くよう変更
- OGP画像を生成するスクリプト(`ui-test/ogp_screenshot.py`)が3月ぐらいから走っていないようなので動くように変更(masterブランチにpushすると走るように)