### PR TITLE
Revert "masterにプッシュするように修正"

### DIFF
--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -56,5 +56,5 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: master
+        branch: deploy/new_ogp
         force: true


### PR DESCRIPTION
Reverts covid19-tochigi/covid19#81

checkout されるのが staging ブランチとなっているが、栃木版では staging ブランチを運用していない。
そのため、 OGP push 時に --force で master へマージすると、今までの栃木版での修正が無視されてしまう。
